### PR TITLE
Fix: タイピングミスを毎回カウントする

### DIFF
--- a/program.js
+++ b/program.js
@@ -336,6 +336,12 @@ document.addEventListener('keydown', function (event) {
 
    // すでにミスロック中なら、正解以外は無視（連打でmiss回数が増えないようにする）
     if (missLock && inputStr !== expected) {
+        countMiss++;
+        document.querySelector(".score4").textContent = `${countMiss} 回`;
+
+        // 見た目のミス演出が必要なら（元からある関数に合わせて）
+        missColor(inputStr);
+        
         return;
     }
 


### PR DESCRIPTION
## 概要
特待生試験仕様として、ミスロック中でも
ミス入力のたびにミス回数を加算するよう修正しました。

## 変更内容
- 同一文字に対するミスも入力ごとにカウント
- ミスロックの挙動（正解が来るまで進まない）は維持

## 動作確認
- Spaceキーで開始できること
- 同じ文字でミスを連打すると、ミス回数が毎回増えること
- 正解入力で次の文字に進むこと
- Consoleエラーなし
